### PR TITLE
use connection_options when specified

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -98,7 +98,7 @@ module Vertebrae
         },
         :ssl => ssl,
         :url => endpoint
-      }
+      }.merge(connection_options)
     end
 
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -71,4 +71,38 @@ describe Vertebrae::Configuration do
       expect(subject.adapter).to eq(:foo)
     end
   end
+
+  describe '#faraday_options' do
+    subject { Vertebrae::Configuration.new(host: 'example.com') }
+
+    it 'should include headers, ssl, and url settings by default' do
+      opts = subject.faraday_options
+      expect(opts.keys).to contain_exactly(:headers, :ssl, :url)
+      expect(opts[:headers]).to eq({'Accept' => 'application/json;q=0.1',
+                                    'Accept-Charset' => 'utf-8',
+                                    'User-Agent' => 'Vertebrae REST Gem',
+                                    'Content-Type' => 'application/json'})
+      expect(opts[:ssl]).to eq({})
+      expect(opts[:url]).to eq 'https://example.com/'
+    end
+
+    context 'with connection_options' do
+      let(:connection_options) { {ssl: {verify: false},
+                                  timeout: 5} }
+
+      subject { Vertebrae::Configuration.new(host: 'example.com', connection_options: connection_options) }
+
+      it 'should override and extend the default options' do
+        opts = subject.faraday_options
+        expect(opts.keys).to contain_exactly(:headers, :ssl, :timeout, :url)
+        expect(opts[:headers]).to eq({'Accept' => 'application/json;q=0.1',
+                                      'Accept-Charset' => 'utf-8',
+                                      'User-Agent' => 'Vertebrae REST Gem',
+                                      'Content-Type' => 'application/json'})
+        expect(opts[:ssl]).to eq({verify: false})
+        expect(opts[:url]).to eq 'https://example.com/'
+        expect(opts[:timeout]).to eq 5
+      end
+    end
+  end
 end


### PR DESCRIPTION
This updates our Faraday initialization to include the `connection_options` configuration parameter, which was previously ignored.

These `faraday_options` are used when we [call Faraday.new](https://github.com/controlshift/vertebrae/blob/master/lib/connection.rb#L69). This fix will allow us to pass in a `timeout` setting.