### PR TITLE
allow additional_headers argument to configuration

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -15,7 +15,8 @@ module Vertebrae
         :connection_options,
         :content_type,
         :scheme,
-        :port
+        :port,
+        :additional_headers
     ].freeze
 
     # The default HTTP scheme configuration
@@ -49,7 +50,7 @@ module Vertebrae
     DEFAULT_CONNECTION_OPTIONS = {}
 
     DEFAULT_CONTENT_TYPE = 'application/json'.freeze
-
+    DEFAULT_ADDITIONAL_HEADERS = {}.freeze
 
     VALID_OPTIONS_KEYS.each do | key |
       define_method("default_#{key}".intern) { default_options[key] }
@@ -95,7 +96,7 @@ module Vertebrae
           ACCEPT_CHARSET   => "utf-8",
           USER_AGENT       => user_agent,
           CONTENT_TYPE     => content_type
-        },
+        }.merge(additional_headers),
         :ssl => ssl,
         :url => endpoint
       }.merge(connection_options)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -104,5 +104,23 @@ describe Vertebrae::Configuration do
         expect(opts[:timeout]).to eq 5
       end
     end
+
+    context 'with additional_headers' do
+      let(:additional_headers) { {'special-auth-token' => 'abcde12345'} }
+
+      subject { Vertebrae::Configuration.new(host: 'example.com', additional_headers: additional_headers) }
+
+      it 'should add the additional headers to the other headers' do
+        opts = subject.faraday_options
+        expect(opts.keys).to contain_exactly(:headers, :ssl, :url)
+        expect(opts[:headers]).to eq({'Accept' => 'application/json;q=0.1',
+                                      'Accept-Charset' => 'utf-8',
+                                      'User-Agent' => 'Vertebrae REST Gem',
+                                      'Content-Type' => 'application/json',
+                                      'special-auth-token' => 'abcde12345'})
+        expect(opts[:ssl]).to eq({})
+        expect(opts[:url]).to eq 'https://example.com/'
+      end
+    end
   end
 end


### PR DESCRIPTION
This updates the `Vertebrae::Configuration` class to support an `additional_headers` option. This will allow us to pass the `OSDI-API-Token` to the ActionNetwork API as required.